### PR TITLE
PLAT-1083 Use edx-sphinx-theme for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    condition: '$TOXENV = py35-django19'
+    condition: '$TOXENV = quality'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,20 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.1] - 2016-10-11
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+_______
+
+* Fix Travis configuration for PyPI deployments.
+* Switch from the Read the Docs Sphinx theme to the Open edX one for documentation.
+
+
+[0.1.0] - 2016-10-07
+~~~~~~~~~~~~~~~~~~~~
+
 Added
 _____
 
-* First release on PyPI.
+* First attempt to release on PyPI.

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,29 @@
-Part of `edX code`__.
+django-user-tasks
+=================
 
-__ http://code.edx.org/
+.. image:: https://img.shields.io/pypi/v/django-user-tasks.svg
+    :target: https://pypi.python.org/pypi/django-user-tasks/
+    :alt: PyPI
 
-django-user-tasks  |Travis|_ |Codecov|_
-=======================================
-.. |Travis| image:: https://travis-ci.org/edx/django-user-tasks.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/django-user-tasks
+.. image:: https://travis-ci.org/edx/django-user-tasks.svg?branch=master
+    :target: https://travis-ci.org/edx/django-user-tasks
+    :alt: Travis
 
-.. |Codecov| image:: http://codecov.io/github/edx/django-user-tasks/coverage.svg?branch=master
-.. _Codecov: http://codecov.io/github/edx/django-user-tasks?branch=master
+.. image:: http://codecov.io/github/edx/django-user-tasks/coverage.svg?branch=master
+    :target: http://codecov.io/github/edx/django-user-tasks?branch=master
+    :alt: Codecov
+
+.. image:: http://django-user-tasks.readthedocs.io/en/latest/?badge=latest
+    :target: http://django-user-tasks.readthedocs.io/en/latest/
+    :alt: Documentation
+
+.. image:: https://img.shields.io/pypi/pyversions/django-user-tasks.svg
+    :target: https://pypi.python.org/pypi/django-user-tasks/
+    :alt: Supported Python versions
+
+.. image:: https://img.shields.io/github/license/edx/django-user-tasks.svg
+    :target: https://github.com/edx/django-user-tasks/blob/master/LICENSE.txt
+    :alt: License
 
 django-user-tasks is a reusable Django application for managing user-triggered
 asynchronous tasks.  It provides a status page for each such task, which
@@ -85,9 +100,10 @@ Reporting Security Issues
 
 Please do not report security issues in public. Please email security@edx.org.
 
-Mailing List and IRC Channel
-----------------------------
+Getting Help
+------------
 
-You can discuss this code in the `edx-code Google Group`__ or in the ``#edx-code`` IRC channel on Freenode.
+Have a question about this repository, or about Open edX in general?  Please
+refer to this `list of resources`_ if you need any assistance.
 
-__ https://groups.google.com/forum/#!forum/edx-code
+.. _list of resources: https://open.edx.org/getting-help

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,17 +19,13 @@ import os
 import sys
 from subprocess import check_call
 
-# Configure Django for autodoc usage
+import edx_theme
+
 import django
+from django.utils import six
+
+# Configure Django for autodoc usage
 django.setup()
-
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme  # pylint: disable=wrong-import-position
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -49,6 +45,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'edx_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -78,8 +75,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'django-user-tasks'
-copyright = '2016, edX Inc.'  # pylint: disable=redefined-builtin
-author = 'edX Inc.'
+copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin
+author = edx_theme.AUTHOR
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -147,8 +144,8 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-# html_theme = 'sphinx_rtd_theme'
+
+html_theme = 'edx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -157,7 +154,7 @@ todo_include_todos = False
 # html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-# html_theme_path = []
+html_theme_path = [edx_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
@@ -289,7 +286,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'django-user-tasks.tex', 'django-user-tasks Documentation',
-     'edX Inc.', 'manual'),
+     author, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -486,7 +483,7 @@ def on_init(app):  # pylint: disable=unused-argument
 
 def setup(app):
     """
-    Sphinx extension: run sphinx-apidoc and apply some CSS overrides to the output theme.
+    Sphinx extension: run sphinx-apidoc and swg2rst.
     """
-    app.connect('builder-inited', on_init)
-    app.add_stylesheet('theme_overrides.css')
+    event = 'builder-inited' if six.PY3 else b'builder-inited'
+    app.connect(event, on_init)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,9 +7,9 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-celery==3.1.23
+celery==3.1.24
 django-model-utils==2.6
-Django==1.10.1            # via django-model-utils
+Django==1.10.2            # via django-model-utils
 djangorestframework==3.4.7
-kombu==3.0.35             # via celery
-pytz==2016.6.1            # via celery
+kombu==3.0.37             # via celery
+pytz==2016.7              # via celery

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,9 +11,9 @@ caniusepython3==4.0.0
 click==6.6                # via pip-tools
 clint==0.5.1              # via twine
 colorama==0.3.7           # via pylint
-distlib==0.2.3            # via caniusepython3
-django==1.10.1            # via edx-i18n-tools
-edx-i18n-tools==0.3.3
+distlib==0.2.4            # via caniusepython3
+django==1.10.2            # via edx-i18n-tools
+edx-i18n-tools==0.3.4
 edx-lint==0.5.1
 first==2.0.1              # via pip-tools
 futures==3.0.5            # via caniusepython3
@@ -27,12 +27,12 @@ pluggy==0.3.1             # via tox
 polib==1.0.7              # via edx-i18n-tools
 py==1.4.31                # via tox
 pycodestyle==2.0.0
-pydocstyle==1.0.0
+pydocstyle==1.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
 pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.1.9          # via packaging
+pyparsing==2.1.10         # via packaging
 pyYaml==3.12              # via edx-i18n-tools
 requests-toolbelt==0.7.0  # via twine
 requests==2.11.1          # via caniusepython3, requests-toolbelt, twine

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -2,8 +2,8 @@
 
 django-rest-swagger       # Generates a Swagger/Open API schema for the REST API
 doc8                      # reStructuredText style checker
+edx-sphinx-theme          # edX theme for Sphinx output
 readme_renderer           # Validates README.rst for usage on PyPI
 rules                     # Needed to import user_tasks/rules.py for autodoc
 Sphinx                    # Documentation builder
-sphinx_rtd_theme          # ReadTheDocs theme for Sphinx output
 swagger2rst               # Generates REST API documentation for Sphinx from a Swagger/Open API schema JSON file

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -11,36 +11,36 @@ babel==2.3.4              # via sphinx
 billiard==3.3.0.23        # via celery
 bleach==1.4.3             # via readme-renderer
 cached-property==1.3.0    # via swagger2rst
-celery==3.1.23
+celery==3.1.24
 chardet==2.3.0            # via doc8
 coreapi==2.0.8            # via django-rest-swagger, openapi-codec
 django-model-utils==2.6
-django-rest-swagger==2.0.5
-Django==1.10.1            # via django-model-utils
+django-rest-swagger==2.0.6
+Django==1.10.2            # via django-model-utils
 djangorestframework==3.4.7
 doc8==0.7.0
 docutils==0.12            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+edx-sphinx-theme==1.0
 html5lib==0.9999999       # via bleach
 imagesize==0.7.1          # via sphinx
 itypes==1.1.0             # via coreapi
 Jinja2==2.8               # via sphinx, swagger2rst
 jsonschema==2.5.1         # via swagger2rst
-kombu==3.0.35             # via celery
+kombu==3.0.37             # via celery
 MarkupSafe==0.23          # via jinja2
-openapi-codec==1.1.0      # via django-rest-swagger
+openapi-codec==1.1.4      # via django-rest-swagger
 pbr==1.10.0               # via stevedore
 Pygments==2.1.3           # via readme-renderer, sphinx
-pytz==2016.6.1            # via babel, celery
+pytz==2016.7              # via babel, celery
 PyYAML==3.12              # via swagger2rst
 readme-renderer==0.7.0
 requests==2.11.1          # via coreapi
-restructuredtext-lint==0.17.1  # via doc8
+restructuredtext-lint==0.17.2  # via doc8
 rules==1.1.1
 simplejson==3.8.2         # via django-rest-swagger
-six==1.10.0               # via bleach, doc8, html5lib, readme-renderer, sphinx, stevedore
+six==1.10.0               # via bleach, doc8, edx-sphinx-theme, html5lib, readme-renderer, sphinx, stevedore
 snowballstemmer==1.2.1    # via sphinx
-sphinx-rtd-theme==0.1.9
-Sphinx==1.4.6             # via sphinx-rtd-theme
+Sphinx==1.4.8             # via edx-sphinx-theme
 stevedore==1.17.1         # via doc8
 strict-rfc3339==0.7       # via swagger2rst
 swagger2rst==0.0.4

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,19 +8,19 @@ argparse==1.4.0           # via caniusepython3
 astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
 caniusepython3==4.0.0
 colorama==0.3.7           # via pylint
-distlib==0.2.3            # via caniusepython3
+distlib==0.2.4            # via caniusepython3
 edx-lint==0.5.1
 futures==3.0.5            # via caniusepython3
 isort==4.2.5
 lazy-object-proxy==1.2.2  # via astroid
 packaging==16.7           # via caniusepython3
 pycodestyle==2.0.0
-pydocstyle==1.0.0
+pydocstyle==1.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
 pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.1.9          # via packaging
+pyparsing==2.1.10         # via packaging
 requests==2.11.1          # via caniusepython3
 six==1.10.0               # via astroid, edx-lint, packaging, pylint
 wrapt==1.10.8             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,20 +7,20 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-celery==3.1.23
+celery==3.1.24
 coverage==4.2             # via pytest-cov
 django-model-utils==2.6
 djangorestframework==3.4.7
-kombu==3.0.35             # via celery
+kombu==3.0.37             # via celery
 mock==2.0.0
 packaging==16.7
 pbr==1.10.0               # via mock
 py==1.4.31                # via pytest, pytest-catchlog
-pyparsing==2.1.9          # via packaging
+pyparsing==2.1.10         # via packaging
 pytest-catchlog==1.2.2
-pytest-cov==2.3.1
+pytest-cov==2.4.0
 pytest-django==3.0.0
-pytest==3.0.2             # via pytest-catchlog, pytest-cov, pytest-django
-pytz==2016.6.1            # via celery
+pytest==3.0.3             # via pytest-catchlog, pytest-cov, pytest-django
+pytz==2016.7              # via celery
 rules==1.1.1
 six==1.10.0               # via mock, packaging

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ exclude = .git,.tox,migrations
 max-line-length = 120
 
 [pydocstyle]
-ignore = D200,D203
+ignore = D200,D203,D212
 match-dir = (?!migrations)
 
 [pytest]

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.dispatch import Signal
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 


### PR DESCRIPTION
* Switch the docs to use edx-sphinx-theme
* Fix the Travis conditions for uploading a PyPI release
* More badges on the README, and don't let them vanish on PyPI (which strips the title line)
* Upgrade assorted dependencies (and ignore one of the 2 mutually exclusive new pydocstyle warnings about starting a multi-line comment)