### PR TITLE
Fix Read the Docs builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,9 @@ import edx_theme
 import django
 from django.utils import six
 
+sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), '..'))
+os.environ['DJANGO_SETTINGS_MODULE'] = 'schema.settings'
+
 # Configure Django for autodoc usage
 django.setup()
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,7 @@ packaging==16.7           # via caniusepython3
 path.py==8.2.1            # via edx-i18n-tools
 pip-tools==1.7.0
 pkginfo==1.3.2            # via twine
-pluggy==0.3.1             # via tox
+pluggy==0.4.0             # via tox
 polib==1.0.7              # via edx-i18n-tools
 py==1.4.31                # via tox
 pycodestyle==2.0.0
@@ -38,7 +38,7 @@ requests-toolbelt==0.7.0  # via twine
 requests==2.11.1          # via caniusepython3, requests-toolbelt, twine
 six==1.10.0               # via astroid, edx-i18n-tools, edx-lint, packaging, pip-tools, pylint
 tox-battery==0.2
-tox==2.3.1
+tox==2.4.1
 twine==1.8.1
 virtualenv==15.0.3        # via tox
 wheel==0.29.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -28,7 +28,7 @@ Jinja2==2.8               # via sphinx, swagger2rst
 jsonschema==2.5.1         # via swagger2rst
 kombu==3.0.37             # via celery
 MarkupSafe==0.23          # via jinja2
-openapi-codec==1.1.4      # via django-rest-swagger
+openapi-codec==1.1.5      # via django-rest-swagger
 pbr==1.10.0               # via stevedore
 Pygments==2.1.3           # via readme-renderer, sphinx
 pytz==2016.7              # via babel, celery

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,9 +7,9 @@
 argparse==1.4.0           # via codecov
 codecov==2.0.5
 coverage==4.2             # via codecov
-pluggy==0.3.1             # via tox
+pluggy==0.4.0             # via tox
 py==1.4.31                # via tox
 requests==2.11.1          # via codecov
 tox-battery==0.2
-tox==2.3.1
+tox==2.4.1
 virtualenv==15.0.3        # via tox

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,6 @@ commands =
     pytest {posargs}
 
 [testenv:docs]
-setenv =
-    DJANGO_SETTINGS_MODULE = schema.settings
-    PYTHONPATH = {toxinidir}
 whitelist_externals =
     make
     rm


### PR DESCRIPTION
Builds were failing on Read the Docs because it doesn't set `DJANGO_SETTINGS_MODULE` like tox does.  Now doing this directly in `docs/conf.py` instead.

Also upgraded dependencies again via pip-compile; no major changes.