### PR TITLE
Better handling of delayed transaction commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 python:
   - 2.7
-  - 3.5
+  - 3.6
 
 env:
   - TOXENV=django18
@@ -13,9 +13,9 @@ env:
 
 matrix:
   include:
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=quality
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=docs
 
 cache:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,23 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+*
+
+[0.1.4] - 2017-01-30
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
++++++++
+
+* Slightly improved handling of tasks which start before their status records
+  are committed (due to database transactions).  Also documented how to avoid
+  this problem in the first place.
+
 [0.1.3] - 2017-01-03
 ~~~~~~~~~~~~~~~~~~~~
 
 Changed
--------
++++++++
 
 * Tasks which were explicitly canceled, failed, or retried no longer have
   their status changed to ``Succeeded`` just because the task exited cleanly.
@@ -30,7 +42,7 @@ Changed
 ~~~~~~~~~~~~~~~~~~~~
 
 Changed
--------
++++++++
 
 * Add a migration to explicitly reference the setting for artifact file storage.
   This setting is likely to vary between installations, but doesn't affect the
@@ -41,7 +53,7 @@ Changed
 ~~~~~~~~~~~~~~~~~~~~
 
 Changed
-_______
++++++++
 
 * Fix Travis configuration for PyPI deployments.
 * Switch from the Read the Docs Sphinx theme to the Open edX one for documentation.
@@ -51,6 +63,6 @@ _______
 ~~~~~~~~~~~~~~~~~~~~
 
 Added
-_____
++++++
 
 * First attempt to release on PyPI.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -454,7 +454,7 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),
+    'python': ('https://docs.python.org/3.6', None),
     'celery': ('http://docs.celeryproject.org/en/latest/', None),
     'django': ('https://docs.djangoproject.com/en/1.10/', 'https://docs.djangoproject.com/en/1.10/_objects/'),
     'model_utils': ('https://django-model-utils.readthedocs.io/en/latest/', None),

--- a/docs/internationalization.rst
+++ b/docs/internationalization.rst
@@ -6,7 +6,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/conventions/internationalization/i18n.html
 
 Updating Translations
 ~~~~~~~~~~~~~~~~~~~~~

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 
-celery                    # Asynchronous task execution library
+celery<4.0                # Asynchronous task execution library
 Django                    # Web application framework
 django-model-utils        # Provides TimeStampedModel abstract base class
 djangorestframework       # REST API framework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,9 +7,9 @@
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-celery==3.1.24
-django-model-utils==2.6
-Django==1.10.2            # via django-model-utils
-djangorestframework==3.4.7
+celery==3.1.25
+django-model-utils==2.6.1
+Django==1.10.5            # via django-model-utils
+djangorestframework==3.5.3
 kombu==3.0.37             # via celery
-pytz==2016.7              # via celery
+pytz==2016.10             # via celery

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,9 +1,9 @@
 # Additional requirements for development of this application
 
 edx-lint                  # For updating pylintrc
-edx-i18n-tools>=0.3.3     # For i18n_tool dummy
+edx-i18n-tools            # For i18n_tool dummy
 pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes
+tox-battery==0.2          # Makes tox aware of requirements file changes (pinned due to https://github.com/signalpillar/tox-battery/issues/6)
 twine                     # Utility for PyPI package uploads
 wheel                     # For generation of wheels for PyPI

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in requirements/quality.in
 #
+appdirs==1.4.0            # via setuptools
 argparse==1.4.0           # via caniusepython3
 args==0.1.0               # via clint
-astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
+astroid==1.4.9            # via pylint, pylint-celery, pylint-plugin-utils
 caniusepython3==4.0.0
-click==6.6                # via pip-tools
+click==6.7                # via pip-tools
 clint==0.5.1              # via twine
-colorama==0.3.7           # via pylint
 distlib==0.2.4            # via caniusepython3
-django==1.10.2            # via edx-i18n-tools
-edx-i18n-tools==0.3.4
-edx-lint==0.5.1
+django==1.10.5            # via edx-i18n-tools
+edx-i18n-tools==0.3.7
+edx-lint==0.5.2
 first==2.0.1              # via pip-tools
 futures==3.0.5            # via caniusepython3
 isort==4.2.5
 lazy-object-proxy==1.2.2  # via astroid
-packaging==16.7           # via caniusepython3
-path.py==8.2.1            # via edx-i18n-tools
-pip-tools==1.7.0
-pkginfo==1.3.2            # via twine
+mccabe==0.6.0             # via pylint
+packaging==16.8           # via caniusepython3, setuptools
+path.py==10.1             # via edx-i18n-tools
+pip-tools==1.8.0
+pkginfo==1.4.1            # via twine
 pluggy==0.4.0             # via tox
-polib==1.0.7              # via edx-i18n-tools
-py==1.4.31                # via tox
-pycodestyle==2.0.0
+polib==1.0.8              # via edx-i18n-tools
+py==1.4.32                # via tox
+pycodestyle==2.2.0
 pydocstyle==1.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
-pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==1.6.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.1.10         # via packaging
 pyYaml==3.12              # via edx-i18n-tools
 requests-toolbelt==0.7.0  # via twine
-requests==2.11.1          # via caniusepython3, requests-toolbelt, twine
-six==1.10.0               # via astroid, edx-i18n-tools, edx-lint, packaging, pip-tools, pylint
+requests==2.13.0          # via caniusepython3, requests-toolbelt, twine
+six==1.10.0               # via astroid, edx-i18n-tools, edx-lint, packaging, pip-tools, pylint, setuptools
 tox-battery==0.2
-tox==2.4.1
+tox==2.5.0
 twine==1.8.1
-virtualenv==15.0.3        # via tox
+virtualenv==15.1.0        # via tox
 wheel==0.29.0
 wrapt==1.10.8             # via astroid
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # pip                       # via caniusepython3
 # setuptools                # via caniusepython3, twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,39 +9,39 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 babel==2.3.4              # via sphinx
 billiard==3.3.0.23        # via celery
-bleach==1.4.3             # via readme-renderer
+bleach==1.5.0             # via readme-renderer
 cached-property==1.3.0    # via swagger2rst
-celery==3.1.24
+celery==3.1.25
 chardet==2.3.0            # via doc8
-coreapi==2.0.8            # via django-rest-swagger, openapi-codec
-django-model-utils==2.6
-django-rest-swagger==2.0.6
-Django==1.10.2            # via django-model-utils
-djangorestframework==3.4.7
+coreapi==2.1.1            # via django-rest-swagger, openapi-codec
+django-model-utils==2.6.1
+django-rest-swagger==2.1.1
+Django==1.10.5            # via django-model-utils
+djangorestframework==3.5.3
 doc8==0.7.0
-docutils==0.12            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.0
+docutils==0.13.1          # via doc8, readme-renderer, restructuredtext-lint, sphinx
+edx-sphinx-theme==1.0.2
 html5lib==0.9999999       # via bleach
 imagesize==0.7.1          # via sphinx
 itypes==1.1.0             # via coreapi
-Jinja2==2.8               # via sphinx, swagger2rst
+Jinja2==2.9.4             # via sphinx, swagger2rst
 jsonschema==2.5.1         # via swagger2rst
 kombu==3.0.37             # via celery
 MarkupSafe==0.23          # via jinja2
-openapi-codec==1.1.5      # via django-rest-swagger
+openapi-codec==1.2.1      # via django-rest-swagger
 pbr==1.10.0               # via stevedore
-Pygments==2.1.3           # via readme-renderer, sphinx
-pytz==2016.7              # via babel, celery
+Pygments==2.2.0           # via readme-renderer, sphinx
+pytz==2016.10             # via babel, celery
 PyYAML==3.12              # via swagger2rst
-readme-renderer==0.7.0
-requests==2.11.1          # via coreapi
+readme-renderer==16.0
+requests==2.13.0          # via coreapi, sphinx
 restructuredtext-lint==0.17.2  # via doc8
-rules==1.1.1
-simplejson==3.8.2         # via django-rest-swagger
+rules==1.2
+simplejson==3.10.0        # via django-rest-swagger
 six==1.10.0               # via bleach, doc8, edx-sphinx-theme, html5lib, readme-renderer, sphinx, stevedore
 snowballstemmer==1.2.1    # via sphinx
-Sphinx==1.4.8             # via edx-sphinx-theme
-stevedore==1.17.1         # via doc8
+Sphinx==1.5.2             # via edx-sphinx-theme
+stevedore==1.20.0         # via doc8
 strict-rfc3339==0.7       # via swagger2rst
 swagger2rst==0.0.4
 uritemplate==3.0.0        # via coreapi

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,28 +4,28 @@
 #
 #    pip-compile --output-file requirements/quality.txt requirements/quality.in
 #
+appdirs==1.4.0            # via setuptools
 argparse==1.4.0           # via caniusepython3
-astroid==1.4.8            # via pylint, pylint-celery, pylint-plugin-utils
+astroid==1.4.9            # via pylint, pylint-celery, pylint-plugin-utils
 caniusepython3==4.0.0
-colorama==0.3.7           # via pylint
 distlib==0.2.4            # via caniusepython3
-edx-lint==0.5.1
+edx-lint==0.5.2
 futures==3.0.5            # via caniusepython3
 isort==4.2.5
 lazy-object-proxy==1.2.2  # via astroid
-packaging==16.7           # via caniusepython3
-pycodestyle==2.0.0
+mccabe==0.6.0             # via pylint
+packaging==16.8           # via caniusepython3, setuptools
+pycodestyle==2.2.0
 pydocstyle==1.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.4  # via pylint-celery, pylint-django
-pylint==1.5.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==1.6.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.1.10         # via packaging
-requests==2.11.1          # via caniusepython3
-six==1.10.0               # via astroid, edx-lint, packaging, pylint
+requests==2.13.0          # via caniusepython3
+six==1.10.0               # via astroid, edx-lint, packaging, pylint, setuptools
 wrapt==1.10.8             # via astroid
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # pip                       # via caniusepython3
 # setuptools                # via caniusepython3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,21 +6,25 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
+appdirs==1.4.0            # via setuptools
 billiard==3.3.0.23        # via celery
-celery==3.1.24
-coverage==4.2             # via pytest-cov
-django-model-utils==2.6
-djangorestframework==3.4.7
+celery==3.1.25
+coverage==4.3.4           # via pytest-cov
+django-model-utils==2.6.1
+djangorestframework==3.5.3
 kombu==3.0.37             # via celery
 mock==2.0.0
-packaging==16.7
+packaging==16.8
 pbr==1.10.0               # via mock
-py==1.4.31                # via pytest, pytest-catchlog
+py==1.4.32                # via pytest, pytest-catchlog
 pyparsing==2.1.10         # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.4.0
-pytest-django==3.0.0
-pytest==3.0.3             # via pytest-catchlog, pytest-cov, pytest-django
-pytz==2016.7              # via celery
-rules==1.1.1
-six==1.10.0               # via mock, packaging
+pytest-django==3.1.2
+pytest==3.0.6             # via pytest-catchlog, pytest-cov, pytest-django
+pytz==2016.10             # via celery
+rules==1.2
+six==1.10.0               # via mock, packaging, setuptools
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools                # via pytest

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -2,4 +2,4 @@
 
 codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes
+tox-battery==0.2          # Makes tox aware of requirements file changes (pinned due to https://github.com/signalpillar/tox-battery/issues/6)

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,10 +6,10 @@
 #
 argparse==1.4.0           # via codecov
 codecov==2.0.5
-coverage==4.2             # via codecov
+coverage==4.3.4           # via codecov
 pluggy==0.4.0             # via tox
-py==1.4.31                # via tox
-requests==2.11.1          # via codecov
+py==1.4.32                # via tox
+requests==2.13.0          # via codecov
 tox-battery==0.2
-tox==2.4.1
-virtualenv==15.0.3        # via tox
+tox==2.5.0
+virtualenv==15.1.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -89,6 +89,7 @@ def receiver(sender, **kwargs):  # pylint: disable=unused-argument
         SIGNAL_DATA['received_status'].state += ' again'
     SIGNAL_DATA['received_status'] = kwargs.get('status')
 
+
 user_task_stopped.connect(receiver)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = {py27,py35}-django{18,19,110}
+envlist = {py27,py36}-django{18,19,110}
 
 [doc8]
 max-line-length = 120
 
-[pep8]
+[pycodestyle]
 exclude = .git,.tox,migrations
 max-line-length = 120
 

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.dispatch import Signal
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 

--- a/user_tasks/apps.py
+++ b/user_tasks/apps.py
@@ -20,4 +20,4 @@ class UserTasksConfig(AppConfig):
         """
         Register Celery signal handlers.
         """
-        import user_tasks.signals  # pylint: disable=unused-import
+        import user_tasks.signals  # pylint: disable=unused-variable

--- a/user_tasks/conf.py
+++ b/user_tasks/conf.py
@@ -67,4 +67,5 @@ class LazySettings(object):
         """
         return getattr(django_settings, 'USER_TASKS_STATUS_FILTERS', (filters.StatusFilterBackend,))
 
+
 settings = LazySettings()  # pylint: disable=invalid-name

--- a/user_tasks/rules.py
+++ b/user_tasks/rules.py
@@ -52,6 +52,7 @@ def is_artifact_creator(user, artifact=None):
         return True
     return is_status_creator(user, artifact.status)
 
+
 STATUS_PERMISSION = is_status_creator | rules.predicates.is_superuser
 ARTIFACT_PERMISSION = is_artifact_creator | rules.predicates.is_superuser
 


### PR DESCRIPTION
Added some code and documentation to help prevent race conditions due to delays in committing the status record for new tasks.  I ran afoul of this when testing a view with atomic requests enabled.  The subsequent Travis run ran afoul of the setuptools upgrade, so I also did a bit of cleanup:

* Updated testing dependency versions
* Fixed minor issues reported by the newer pylint version
* Switched Python 3 testing from 3.5 to 3.6
* Fixed a minor formatting issue with the changelog section titles