### PR TITLE
Fix the make upgrade file order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
 cache:
   - pip
 
+branches:
+  only:
+    - master
+    - /v?^\d+\.\d+(\.\d+)?(-\S*)?$/
+
 install:
   - pip install -r requirements/travis.txt
 

--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,17 @@ extract_translations: ## extract strings to be translated, outputting .mo files
 
 fake_translations: extract_translations dummy_translations compile_translations ## generate and compile dummy translation files
 
+# Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
+PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q pip-tools
-	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
-	pip-compile --rebuild --upgrade -o requirements/doc.txt requirements/doc.in
-	pip-compile --rebuild --upgrade -o requirements/quality.txt requirements/quality.in
-	pip-compile --rebuild --upgrade -o requirements/dev.txt requirements/dev.in
-	pip-compile --rebuild --upgrade -o requirements/travis.txt requirements/travis.in
+	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
+	$(PIP_COMPILE) -o requirements/doc.txt requirements/doc.in
+	$(PIP_COMPILE) -o requirements/quality.txt requirements/quality.in
+	$(PIP_COMPILE) -o requirements/travis.txt requirements/travis.in
+	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django version for tests
 	sed '/^django==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,26 +14,26 @@ backports.functools-lru-cache==1.5
 billiard==3.3.0.23
 caniusepython3==7.1.0
 celery==3.1.26.post2
-certifi==2019.3.9
+certifi==2019.6.16
 chardet==3.0.4
 click-log==0.3.2
 click==7.0
 codecov==2.0.15
 configparser==3.7.4
-contextlib2==0.5.5        # via importlib-metadata
+contextlib2==0.5.5
 coverage==4.5.3
 distlib==0.2.9.post0
 django-model-utils==3.1.2
-django==1.11.20
+django==1.11.21
 djangorestframework==3.9.4
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
+edx-lint==1.3.0
 enum34==1.1.6
-filelock==3.0.10
+filelock==3.0.12
 funcsigs==1.0.2
 futures==3.2.0 ; python_version == "2.7"
 idna==2.8
-importlib-metadata==0.12  # via path.py
+importlib-metadata==0.18
 isort==4.3.20
 kombu==3.0.37
 lazy-object-proxy==1.4.1
@@ -43,8 +43,8 @@ more-itertools==5.0.0
 packaging==19.0
 path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.3
-pip-tools==3.7.0
-pluggy==0.11.0
+pip-tools==3.8.0
+pluggy==0.12.0
 polib==1.1.0              # via edx-i18n-tools
 py==1.8.0
 pycodestyle==2.5.0
@@ -56,11 +56,11 @@ pylint==1.7.6
 pyparsing==2.4.0
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0
+pytest-django==3.5.0
+pytest==4.6.3
 pytz==2019.1
-pyyaml==5.1               # via edx-i18n-tools
-requests==2.21.0
+pyyaml==5.1.1             # via edx-i18n-tools
+requests==2.22.0
 rules==2.0.1
 scandir==1.10.0
 singledispatch==3.4.0.3
@@ -68,9 +68,9 @@ six==1.12.0
 snowballstemmer==1.2.1
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.11.0
-urllib3==1.24.3
-virtualenv==16.6.0
+tox==3.12.1
+urllib3==1.25.3
+virtualenv==16.6.1
 wcwidth==0.1.7
-wrapt==1.11.1
-zipp==0.5.0               # via importlib-metadata
+wrapt==1.11.2
+zipp==0.5.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,22 +8,22 @@ alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 attrs==19.1.0             # via jsonschema
-babel==2.6.0              # via sphinx
+babel==2.7.0              # via sphinx
 billiard==3.3.0.23        # via celery
 bleach==3.1.0             # via readme-renderer
 cached-property==1.5.1    # via swagger2rst
 celery==3.1.26.post2
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via doc8, requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 django-model-utils==3.1.2
 django-rest-swagger==2.2.0
-django==1.11.20
+django==1.11.21
 djangorestframework==3.9.4
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.4.0
+edx-sphinx-theme==1.5.0
 functools32==3.2.3.post2 ; python_version == "2.7"  # via jsonschema
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
@@ -34,25 +34,25 @@ kombu==3.0.37             # via celery
 markupsafe==1.1.1         # via jinja2
 openapi-codec==1.3.2      # via django-rest-swagger
 packaging==19.0           # via sphinx
-pbr==5.2.0                # via stevedore
-pygments==2.4.0           # via readme-renderer, sphinx
+pbr==5.3.1                # via stevedore
+pygments==2.4.2           # via readme-renderer, sphinx
 pyparsing==2.4.0          # via packaging
 pyrsistent==0.15.2        # via jsonschema
 pytz==2019.1              # via babel, celery, django
-pyyaml==5.1               # via swagger2rst
+pyyaml==5.1.1             # via swagger2rst
 readme-renderer==24.0
-requests==2.21.0          # via coreapi, sphinx
+requests==2.22.0          # via coreapi, sphinx
 restructuredtext-lint==1.3.0  # via doc8
 rules==2.0.1
 simplejson==3.16.0        # via django-rest-swagger
 six==1.12.0               # via bleach, doc8, edx-sphinx-theme, jsonschema, packaging, pyrsistent, readme-renderer, sphinx, stevedore
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.8.5
-sphinxcontrib-websupport==1.1.0  # via sphinx
+sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.30.1         # via doc8
 strict-rfc3339==0.7       # via swagger2rst
 swagger2rst==0.0.4
-typing==3.6.6             # via sphinx
+typing==3.7.4             # via sphinx
 uritemplate==3.0.0        # via coreapi
-urllib3==1.24.3           # via requests
+urllib3==1.25.3           # via requests
 webencodings==0.5.1       # via bleach

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,13 +8,13 @@ argparse==1.4.0           # via caniusepython3
 astroid==1.5.3            # via pylint, pylint-celery
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 caniusepython3==7.1.0
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
 configparser==3.7.4       # via pydocstyle, pylint
 distlib==0.2.9.post0      # via caniusepython3
-edx-lint==1.1.2
+edx-lint==1.3.0
 enum34==1.1.6             # via astroid
 futures==3.2.0 ; python_version == "2.7"  # via caniusepython3, isort
 idna==2.8                 # via requests
@@ -29,9 +29,9 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.0          # via packaging
-requests==2.21.0          # via caniusepython3
+requests==2.22.0          # via caniusepython3
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.12.0               # via astroid, edx-lint, packaging, pydocstyle, pylint, singledispatch
 snowballstemmer==1.2.1    # via pydocstyle
-urllib3==1.24.3           # via requests
-wrapt==1.11.1             # via astroid
+urllib3==1.25.3           # via requests
+wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,24 +10,28 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 billiard==3.3.0.23        # via celery
 celery==3.1.26.post2
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via pytest-cov
 django-model-utils==3.1.2
 djangorestframework==3.9.4
 funcsigs==1.0.2           # via mock, pytest
+importlib-metadata==0.18  # via pluggy, pytest
 kombu==3.0.37             # via celery
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
 packaging==19.0
-pathlib2==2.3.3           # via pytest, pytest-django
-pluggy==0.11.0            # via pytest
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
+pluggy==0.12.0            # via pytest
 py==1.8.0                 # via pytest, pytest-catchlog
 pyparsing==2.4.0          # via packaging
 pytest-catchlog==1.2.2
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0             # via pytest-catchlog, pytest-cov, pytest-django
+pytest-django==3.5.0
+pytest==4.6.3             # via pytest-catchlog, pytest-cov, pytest-django
 pytz==2019.1              # via celery, django
 rules==2.0.1
 scandir==1.10.0           # via pathlib2
 six==1.12.0               # via mock, more-itertools, packaging, pathlib2, pytest
 wcwidth==0.1.7            # via pytest
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,18 +4,24 @@
 #
 #    make upgrade
 #
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via codecov
-filelock==3.0.10          # via tox
+filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-pluggy==0.11.0            # via tox
+importlib-metadata==0.18  # via pluggy
+pathlib2==2.3.3           # via importlib-metadata
+pluggy==0.12.0            # via tox
 py==1.8.0                 # via tox
-requests==2.21.0          # via codecov
-six==1.12.0               # via tox
+requests==2.22.0          # via codecov
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.11.0
-urllib3==1.24.3           # via requests
-virtualenv==16.6.0        # via tox
+tox==3.12.1
+urllib3==1.25.3           # via requests
+virtualenv==16.6.1        # via tox
+zipp==0.5.1               # via importlib-metadata


### PR DESCRIPTION
Two of the requirements files were out of order in the `make upgrade` target, fix them so it works again.  Also, stop running a duplicate set of tests on branch pushes and make it easier to display verbose output from `pip-compile`.