### PR TITLE
Close old/obsolete connections in start_user_task handler.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+[0.2.0] - 2019-08-30
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
++++++++
+
+* Have the `start_user_task` receiver close obsolete connections before starting the task.
+
+
 [0.1.9] - 2019-08-27
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.dispatch import Signal
 
-__version__ = '0.1.9'
+__version__ = '0.2.0'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 


### PR DESCRIPTION
Meant to address https://openedx.atlassian.net/browse/EDUCATOR-4597