### PR TITLE
Fix search in UserTaskStatusAdmin

### DIFF
--- a/user_tasks/admin.py
+++ b/user_tasks/admin.py
@@ -27,7 +27,9 @@ class UserTaskStatusAdmin(admin.ModelAdmin):
 
     list_display = ('created', 'uuid', 'state', 'user', 'name')
     ordering = ('-created',)
-    search_fields = ('uuid', 'task_id', 'task_class', 'user', 'name')
+    search_fields = (
+        'uuid', 'task_id', 'task_class', 'name', 'user__username', 'user__email'
+    )
 
 
 admin.site.register(UserTaskArtifact, UserTaskArtifactAdmin)


### PR DESCRIPTION
In the admin config, search_fields specified to search task statuses on user, which is a ForeignKey. Instead, we now search on user__username and user__email.