### PR TITLE
check transaction atomicity before forcing closed any django DB connections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+[0.2.1] - 2019-09-25
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
++++++++
+
+* `start_user_task` should only close obsolete connections if the current connection is NOT in an atomic block
+  (which fixes errors on devstack studio/course-publishing).
+
 [0.2.0] - 2019-08-30
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.dispatch import Signal
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 


### PR DESCRIPTION
* Fixes broken devstack course-publishing process.