### PR TITLE
Fix PyPI deployment condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    condition: '$TOXENV = quality'
+    condition: '$TOX_ENV = quality'


### PR DESCRIPTION
The last version bump didn't go out automatically because this environment variable name changed in the rest of the file.  Already used the Jenkins job to do the deployment, so just fixing this for future updates.