### PR TITLE
Adding pin importlib-metadata==1.7.0 and upgrade celery 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/travis.txt requirements/travis.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django and celery versions for tests
-	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==" requirements/base.txt > requirements/celery31.txt
+	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==" requirements/base.txt > requirements/celery44.txt
 	sed -i.tmp '/^[dD]jango==/d' requirements/test.txt
 	sed -i.tmp '/^amqp==/d' requirements/test.txt
 	sed -i.tmp '/^anyjson==/d' requirements/test.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,13 +4,15 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
-billiard==3.3.0.23        # via celery
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in
+amqp==2.6.1               # via kombu
+billiard==3.6.3.0         # via celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in
-kombu==3.0.37             # via celery
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, kombu
+kombu==4.6.11             # via celery
 pytz==2020.1              # via celery, django
 sqlparse==0.3.1           # via django
+vine==1.3.0               # via amqp, celery
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/celery44.txt
+++ b/requirements/celery44.txt
@@ -1,7 +1,4 @@
 amqp==2.6.1               # via kombu
 billiard==3.6.3.0         # via celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
-importlib-metadata==1.7.0  # via kombu
 kombu==4.6.11             # via celery
-vine==1.3.0               # via amqp
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# significant updates required to support celery 4.0.0
-celery<4.0.0
+# v 5.0 drops support of python3.5
+celery<5.0
 
 # Stay on an LTS release
 django<2.3
@@ -17,3 +17,6 @@ django<2.3
 # Requires work, including removal of detail_route. See:
 # https://www.django-rest-framework.org/community/3.8-announcement/#action-decorator-replaces-list_route-and-detail_route
 djangorestframework<3.10.0
+
+# v 2.0 is giving incompatible versions errors on upgrade
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,13 +4,12 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/test.txt, kombu
-anyjson==0.3.3            # via -r requirements/test.txt, kombu
+amqp==2.6.1               # via -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/test.txt, pytest
-billiard==3.3.0.23        # via -r requirements/test.txt, celery
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/test.txt
+billiard==3.6.3.0         # via -r requirements/test.txt, celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt
 certifi==2020.6.20        # via -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
@@ -25,11 +24,11 @@ edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, -r requirements/travis.txt, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, -r requirements/travis.txt, kombu, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
-kombu==3.0.37             # via -r requirements/test.txt, celery
+kombu==4.6.11             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
@@ -65,6 +64,7 @@ tox-battery==0.6.1        # via -r requirements/travis.txt
 tox==3.20.0               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 urllib3==1.25.10          # via -r requirements/travis.txt, requests
+vine==1.3.0               # via -r requirements/test.txt, amqp, celery
 virtualenv==20.0.31       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,14 +5,13 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
+amqp==2.6.1               # via -r requirements/base.txt, kombu
 attrs==20.2.0             # via jsonschema
 babel==2.8.0              # via sphinx
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-bleach==3.2.0             # via readme-renderer
-cached-property==1.5.1    # via swagger2rst
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.txt
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+bleach==3.2.1             # via readme-renderer
+cached-property==1.5.2    # via swagger2rst
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via doc8, requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
@@ -26,11 +25,11 @@ docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sp
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via jsonschema
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/base.txt, jsonschema, kombu
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema, sphinx, swagger2rst
 jsonschema==3.2.0         # via swagger2rst
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.6.11             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via jinja2
 openapi-codec==1.3.2      # via django-rest-swagger
 packaging==20.4           # via bleach, sphinx
@@ -64,8 +63,9 @@ tqdm==4.49.0              # via twine
 twine==1.15.0             # via -r requirements/doc.in
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.10          # via requests
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 webencodings==0.5.1       # via bleach
-zipp==1.2.0               # via importlib-metadata
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ attrs==20.2.0             # via pytest
 coverage==5.3             # via pytest-cov
 django-model-utils==4.0.0  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/base.txt, kombu, pytest
 iniconfig==1.0.1          # via pytest
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.5.0     # via pytest
@@ -22,8 +22,9 @@ pytest-django==3.10.0     # via -r requirements/test.in
 pytest==6.0.2             # via pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/base.txt, celery, django
 rules==2.2                # via -r requirements/test.in
-six==1.15.0               # via mock, packaging, pathlib2
+six==1.15.0               # via mock, packaging
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 testfixtures==6.14.2      # via -r requirements/test.in
 toml==0.10.1              # via pytest
-zipp==1.2.0               # via importlib-metadata
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox


### PR DESCRIPTION
Adding pin importlib-metadata==1.7.0 to avoid error in make upgrade.
Upgrade celery version in base.txt

NOTE:  **In followup PR i will remove the extra celery workers testings from tox.**