### PR TITLE
Removing un-necessary celery versions testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,12 @@ language: python
 matrix:
   include:
   - python: 3.5
-    env: TOX_ENV=py35-django22-celery31
-  - python: 3.5
-    env: TOX_ENV=py35-django22-celery40
-  - python: 3.5
-    env: TOX_ENV=py35-django22-celery42
-  - python: 3.5
-    env: TOX_ENV=py35-django22-celery43
-  - python: 3.5
     env: TOX_ENV=py35-django22-celery44
   - python: 3.8
-    env: TOX_ENV=py38-django22-celery42
-  - python: 3.8
-    env: TOX_ENV=py38-django22-celery43
-  - python: 3.8
     env: TOX_ENV=py38-django22-celery44
-  - python: 3.5
+  - python: 3.8
     env: TOX_ENV=quality
-  - python: 3.5
+  - python: 3.8
     env: TOX_ENV=docs
 
 cache:

--- a/requirements/celery31.txt
+++ b/requirements/celery31.txt
@@ -1,5 +1,0 @@
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
-billiard==3.3.0.23        # via celery
-celery==3.1.26.post2      # via -c requirements/constraints.txt, -r requirements/base.in
-kombu==3.0.37             # via celery

--- a/requirements/celery40.txt
+++ b/requirements/celery40.txt
@@ -1,6 +1,0 @@
-amqp==2.6.1               # via kombu
-billiard==3.5.0.5         # via celery
-celery==4.0.2             # via -c requirements/constraints.txt, -r requirements/base.in
-kombu==4.6.11             # via celery
-vine==1.3.0               # via amqp
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/celery42.txt
+++ b/requirements/celery42.txt
@@ -1,5 +1,0 @@
-amqp==2.6.1               # via kombu
-billiard==3.5.0.5         # via celery
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.in
-kombu==4.3.0              # via celery
-vine==1.3.0               # via amqp

--- a/requirements/celery43.txt
+++ b/requirements/celery43.txt
@@ -1,6 +1,0 @@
-amqp==2.6.1               # via kombu
-billiard==3.6.3.0         # via celery
-celery==4.3.0             # via -c requirements/constraints.txt, -r requirements/base.in
-kombu==4.6.11             # via celery
-vine==1.3.0               # via amqp
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,10 @@
 [tox]
-envlist = py35-django22-celery{31,40,42,43,44},py38-django{22,30}-celery{42,43,44}
+envlist = py35-django22-celery{44},py38-django{22,30}-celery{44}
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
-    celery31: -r{toxinidir}/requirements/celery31.txt
-    celery40: -r{toxinidir}/requirements/celery40.txt
-    celery42: -r{toxinidir}/requirements/celery42.txt
-    celery43: -r{toxinidir}/requirements/celery43.txt
     celery44: -r{toxinidir}/requirements/celery44.txt
     -r{toxinidir}/requirements/test.txt
 commands =
@@ -48,3 +44,4 @@ commands =
     pydocstyle schema tests user_tasks
     isort --check-only --diff --recursive schema tests user_tasks manage.py setup.py test_settings.py
     make help
+


### PR DESCRIPTION
Removing un-necessary celery versions testing.
4.4.7 already deployed in all repos so its safe to remove these test vers.