### PR TITLE
Unpin importlib-metadata constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ celery==4.4.7             # via -c requirements/constraints.txt, -r requirements
 django-model-utils==4.0.0  # via -r requirements/base.in
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, kombu
+importlib-metadata==2.0.0  # via kombu
 kombu==4.6.11             # via celery
 pytz==2020.1              # via celery, django
 sqlparse==0.4.1           # via django

--- a/requirements/celery40.txt
+++ b/requirements/celery40.txt
@@ -1,7 +1,6 @@
 amqp==2.6.1               # via kombu
 billiard==3.5.0.5         # via celery
 celery==4.0.2             # via -c requirements/constraints.txt, -r requirements/base.in
-importlib-metadata==1.7.0  # via kombu
 kombu==4.6.11             # via celery
 vine==1.3.0               # via amqp
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/celery43.txt
+++ b/requirements/celery43.txt
@@ -1,7 +1,6 @@
 amqp==2.6.1               # via kombu
 billiard==3.6.3.0         # via celery
 celery==4.3.0             # via -c requirements/constraints.txt, -r requirements/base.in
-importlib-metadata==1.7.0  # via kombu
 kombu==4.6.11             # via celery
 vine==1.3.0               # via amqp
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,6 +17,3 @@ django<2.3
 # Requires work, including removal of detail_route. See:
 # https://www.django-rest-framework.org/community/3.8-announcement/#action-decorator-replaces-list_route-and-detail_route
 djangorestframework<3.10.0
-
-# v 2.0 is giving incompatible versions errors on upgrade
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ certifi==2020.6.20        # via -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
-codecov==2.1.9            # via -r requirements/travis.txt
+codecov==2.1.10           # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt
@@ -24,7 +24,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, -r requirements/travis.txt, kombu, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/test.txt, -r requirements/travis.txt, kombu, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
@@ -57,14 +57,14 @@ rules==2.2                # via -r requirements/test.txt
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-i18n-tools, edx-lint, mock, packaging, pathlib2, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.4.1           # via -r requirements/test.txt, django
-testfixtures==6.14.2      # via -r requirements/test.txt
+testfixtures==6.15.0      # via -r requirements/test.txt
 toml==0.10.1              # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 urllib3==1.25.10          # via -r requirements/travis.txt, requests
 vine==1.3.0               # via -r requirements/test.txt, amqp, celery
-virtualenv==20.0.33       # via -r requirements/travis.txt, tox
+virtualenv==20.0.34       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -25,7 +25,7 @@ docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sp
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/base.txt, jsonschema, kombu
+importlib-metadata==2.0.0  # via -r requirements/base.txt, jsonschema, kombu
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema, sphinx, swagger2rst
 jsonschema==3.2.0         # via swagger2rst
@@ -40,7 +40,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytz==2020.1              # via -r requirements/base.txt, babel, celery, django
 pyyaml==5.3.1             # via swagger2rst
-readme-renderer==26.0     # via twine
+readme-renderer==27.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via coreapi, requests-toolbelt, sphinx, twine
 restructuredtext-lint==1.3.1  # via doc8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ attrs==20.2.0             # via pytest
 coverage==5.3             # via pytest-cov
 django-model-utils==4.0.0  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/base.txt, kombu, pytest
+importlib-metadata==2.0.0  # via -r requirements/base.txt, kombu, pytest
 iniconfig==1.0.1          # via pytest
 mock==3.0.5               # via -r requirements/test.in
 packaging==20.4           # via -r requirements/test.in, pytest
@@ -23,7 +23,7 @@ pytz==2020.1              # via -r requirements/base.txt, celery, django
 rules==2.2                # via -r requirements/test.in
 six==1.15.0               # via mock, packaging
 sqlparse==0.4.1           # via -r requirements/base.txt, django
-testfixtures==6.14.2      # via -r requirements/test.in
+testfixtures==6.15.0      # via -r requirements/test.in
 toml==0.10.1              # via pytest
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,12 +7,12 @@
 appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
+codecov==2.1.10           # via -r requirements/travis.in
 coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -22,7 +22,7 @@ requests==2.24.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.20.0               # via -r requirements/travis.in, tox-battery
+tox==3.20.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.10          # via requests
-virtualenv==20.0.33       # via tox
+virtualenv==20.0.34       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata` was constrained because `importlib-metadata==2.0.0` was causing conflicts in running `make upgrade` with `python3.5` due to conflicts in `tox` and `virtualenv` requirements.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.