### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[1.3.1] - 2020-11-19
+~~~~~~~~~~~~~~~~~~~~
+* Updated the build status badge in README.rst to point to travis-ci.com instead of travis-ci.org
+
 [1.3.0] - 2020-08-25
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ django-user-tasks
     :target: https://pypi.python.org/pypi/django-user-tasks/
     :alt: PyPI
 
-.. image:: https://travis-ci.org/edx/django-user-tasks.svg?branch=master
-    :target: https://travis-ci.org/edx/django-user-tasks
+.. image:: https://travis-ci.com/edx/django-user-tasks.svg?branch=master
+    :target: https://travis-ci.com/edx/django-user-tasks
     :alt: Travis
 
 .. image:: http://codecov.io/github/edx/django-user-tasks/coverage.svg?branch=master

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089