### PR TITLE
Adding celery50 testing and update import for Task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,13 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ["3.8"]
-        toxenv: ["django22-celery44-drf39", "django22-celery44-drf310", "django22-celery44-drf311", "django22-celery44-drf312", "quality", "docs"]
+        toxenv: [
+          "django22-celery44-drf39", "django22-celery44-drf310",
+          "django22-celery44-drf311", "django22-celery44-drf312",
+          "django22-celery50-drf39", "django22-celery50-drf310",
+          "django22-celery50-drf311", "django22-celery50-drf312",
+          "quality", "docs"
+        ]
 
     steps:
     - uses: actions/checkout@v2
@@ -39,3 +45,4 @@ jobs:
       with:
         flags: unittests
         fail_ci_if_error: true
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,15 @@ Unreleased
 Changed
 +++++++
 
+* Added celery 5.0 testing using tox. Fix pylint warnings. Update the code accordingly.
+
+
+[1.3.2] - 2020-12-17
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
++++++++
+
 * Updated the deprecated celery import class. New import is compatible with 4.4.7 also.
 
 

--- a/Makefile
+++ b/Makefile
@@ -73,15 +73,20 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django, djangorestframework, and celery versions for tests
-	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==" requirements/base.txt > requirements/celery44.txt
-	sed -i.tmp '/^[dD]jango==/d' requirements/test.txt
+	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery44.txt
+	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
 	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
 	sed -i.tmp '/^amqp==/d' requirements/test.txt
 	sed -i.tmp '/^anyjson==/d' requirements/test.txt
 	sed -i.tmp '/^billiard==/d' requirements/test.txt
 	sed -i.tmp '/^celery==/d' requirements/test.txt
 	sed -i.tmp '/^kombu==/d' requirements/test.txt
-	rm requirements/*.txt.tmp
+	sed -i.tmp '/^vine==/d' requirements/test.txt
+	sed -i.tmp '/^click-didyoumean==/d' requirements/test.txt
+	sed -i.tmp '/^click==/d' requirements/test.txt
+	sed -i.tmp '/^prompt-toolkit==/d' requirements/test.txt
+
+	rm requirements/test.txt.tmp
 
 pull_translations: ## pull translations from Transifex
 	tx pull -a

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,7 @@ celery==4.4.7             # via -c requirements/constraints.txt, -r requirements
 django-model-utils==4.1.1  # via -r requirements/base.in
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework
 djangorestframework==3.12.2  # via -r requirements/base.in
-importlib-metadata==2.1.1  # via kombu
 kombu==4.6.11             # via celery
 pytz==2020.4              # via celery, django
 sqlparse==0.4.1           # via django
 vine==1.3.0               # via amqp, celery
-zipp==1.2.0               # via importlib-metadata

--- a/requirements/celery44.txt
+++ b/requirements/celery44.txt
@@ -2,3 +2,4 @@ amqp==2.6.1               # via kombu
 billiard==3.6.3.0         # via celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==4.6.11             # via celery
+vine==1.3.0               # via amqp, celery

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,0 +1,9 @@
+amqp==5.0.2               # via kombu
+billiard==3.6.3.0         # via celery
+celery==5.0.5             # via -c requirements/constraints.txt, -r requirements/base.in
+click-didyoumean==0.0.3   # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl
+kombu==5.0.2              # via celery
+prompt-toolkit==3.0.8     # via click-repl
+vine==5.0.0               # via amqp, celery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,23 +6,20 @@
 #
 appdirs==1.4.4            # via virtualenv
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via requests
-codecov==2.1.10           # via -r requirements/ci.in
-coverage==5.3             # via codecov
+chardet==4.0.0            # via requests
+codecov==2.1.11           # via -r requirements/ci.in
+coverage==5.3.1           # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-packaging==20.7           # via tox
+packaging==20.8           # via tox
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
+py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.25.0          # via codecov
+requests==2.25.1          # via codecov
 six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/ci.in
 tox==3.20.1               # via -r requirements/ci.in, tox-battery
 urllib3==1.26.2           # via requests
 virtualenv==20.2.2        # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,67 +6,62 @@
 #
 amqp==2.6.1               # via -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/ci.txt, virtualenv
-astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
+astroid==2.4.2            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 billiard==3.6.3.0         # via -r requirements/test.txt, celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt
 certifi==2020.12.5        # via -r requirements/ci.txt, requests
-chardet==3.0.4            # via -r requirements/ci.txt, requests
+chardet==4.0.0            # via -r requirements/ci.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
-codecov==2.1.10           # via -r requirements/ci.txt
-coverage==5.3             # via -r requirements/ci.txt, -r requirements/test.txt, codecov, pytest-cov
+codecov==2.1.11           # via -r requirements/ci.txt
+coverage==5.3.1           # via -r requirements/ci.txt, -r requirements/test.txt, codecov, pytest-cov
 distlib==0.3.1            # via -r requirements/ci.txt, virtualenv
 django-model-utils==4.1.1  # via -r requirements/test.txt
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, djangorestframework, edx-i18n-tools
 djangorestframework==3.12.2  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.txt
+edx-lint==1.6             # via -r requirements/dev.in, -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/ci.txt, tox, virtualenv
 idna==2.10                # via -r requirements/ci.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/ci.txt, -r requirements/test.txt, kombu, path, pluggy, pytest, tox, virtualenv
-importlib-resources==3.2.1  # via -r requirements/ci.txt, virtualenv
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/quality.txt, pylint
+isort==5.6.4              # via -r requirements/quality.txt, pylint
 kombu==4.6.11             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
-mock==3.0.5               # via -r requirements/test.txt
-packaging==20.7           # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
+mock==4.0.3               # via -r requirements/test.txt
+packaging==20.8           # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
-path==13.1.0              # via path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+path==15.0.1              # via path.py
 pip-tools==5.4.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-py==1.9.0                 # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
+py==1.10.0                # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.1.1         # via -r requirements/quality.txt
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/ci.txt, -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 pytz==2020.4              # via -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via edx-i18n-tools
-requests==2.25.0          # via -r requirements/ci.txt, codecov
+requests==2.25.1          # via -r requirements/ci.txt, codecov
 rules==2.2                # via -r requirements/test.txt
-six==1.15.0               # via -r requirements/ci.txt, -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/test.txt, astroid, edx-i18n-tools, edx-lint, mock, pathlib2, pip-tools, tox, virtualenv
+six==1.15.0               # via -r requirements/ci.txt, -r requirements/pip-tools.txt, -r requirements/quality.txt, astroid, edx-i18n-tools, edx-lint, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.4.1           # via -r requirements/test.txt, django
-testfixtures==6.16.0      # via -r requirements/test.txt
-toml==0.10.2              # via -r requirements/ci.txt, -r requirements/test.txt, pytest, tox
+testfixtures==6.17.0      # via -r requirements/test.txt
+toml==0.10.2              # via -r requirements/ci.txt, -r requirements/quality.txt, -r requirements/test.txt, pylint, pytest, tox
 tox-battery==0.6.1        # via -r requirements/ci.txt
 tox==3.20.1               # via -r requirements/ci.txt, tox-battery
-typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 urllib3==1.26.2           # via -r requirements/ci.txt, requests
 vine==1.3.0               # via -r requirements/test.txt, amqp, celery
 virtualenv==20.2.2        # via -r requirements/ci.txt, tox
-wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-zipp==1.2.0               # via -r requirements/ci.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
+wrapt==1.12.1             # via -r requirements/quality.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,7 +13,8 @@ bleach==3.2.1             # via readme-renderer
 cached-property==1.5.2    # via swagger2rst
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via doc8, requests
+chardet==4.0.0            # via doc8, requests
+colorama==0.4.4           # via twine
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 django-model-utils==4.1.1  # via -r requirements/base.txt
@@ -22,17 +23,17 @@ django==2.2.17            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.1.1  # via -r requirements/base.txt, jsonschema, kombu
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema, sphinx, swagger2rst
 jsonschema==3.2.0         # via swagger2rst
+keyring==21.7.0           # via twine
 kombu==4.6.11             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via jinja2
 openapi-codec==1.3.2      # via django-rest-swagger
-packaging==20.7           # via bleach, sphinx
+packaging==20.8           # via bleach, sphinx
 pbr==5.5.1                # via stevedore
 pkginfo==1.6.1            # via twine
 pygments==2.7.3           # via doc8, readme-renderer, sphinx
@@ -42,13 +43,14 @@ pytz==2020.4              # via -r requirements/base.txt, babel, celery, django
 pyyaml==5.3.1             # via swagger2rst
 readme-renderer==28.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.25.0          # via coreapi, requests-toolbelt, sphinx, twine
+requests==2.25.1          # via coreapi, requests-toolbelt, sphinx, twine
 restructuredtext-lint==1.3.2  # via doc8
+rfc3986==1.4.0            # via twine
 rules==2.2                # via -r requirements/doc.in
 simplejson==3.17.2        # via django-rest-swagger
-six==1.15.0               # via bleach, doc8, edx-sphinx-theme, jsonschema, readme-renderer, stevedore
+six==1.15.0               # via bleach, doc8, edx-sphinx-theme, jsonschema, readme-renderer
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.4.0             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -56,16 +58,15 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via doc8
+stevedore==3.3.0          # via doc8
 strict-rfc3339==0.7       # via swagger2rst
 swagger2rst==0.0.4        # via -r requirements/doc.in
 tqdm==4.54.1              # via twine
-twine==1.15.0             # via -r requirements/doc.in
+twine==3.2.0              # via -r requirements/doc.in
 uritemplate==3.0.1        # via coreapi
 urllib3==1.26.2           # via requests
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 webencodings==0.5.1       # via bleach
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-wheel==0.36.1             # via -r requirements/pip.in
+wheel==0.36.2             # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3.1               # via -r requirements/pip.in
-setuptools==50.3.2        # via -r requirements/pip.in
+pip==20.3.3               # via -r requirements/pip.in
+setuptools==51.1.0        # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,20 +4,20 @@
 #
 #    make upgrade
 #
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==2.4.2            # via pylint, pylint-celery
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-edx-lint==1.5.2           # via -r requirements/quality.in
-isort==4.3.21             # via -r requirements/quality.in, pylint
+edx-lint==1.6             # via -r requirements/quality.in
+isort==5.6.4              # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.1.1         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 six==1.15.0               # via astroid, edx-lint
 snowballstemmer==2.0.0    # via pydocstyle
-typed-ast==1.4.1          # via astroid
-wrapt==1.11.2             # via astroid
+toml==0.10.2              # via pylint
+wrapt==1.12.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,24 +5,19 @@
 #    make upgrade
 #
 attrs==20.3.0             # via pytest
-coverage==5.3             # via pytest-cov
+coverage==5.3.1           # via pytest-cov
 django-model-utils==4.1.1  # via -r requirements/base.txt
-importlib-metadata==2.1.1  # via -r requirements/base.txt, kombu, pytest
 iniconfig==1.1.1          # via pytest
-mock==3.0.5               # via -r requirements/test.in
-packaging==20.7           # via -r requirements/test.in, pytest
-pathlib2==2.3.5           # via pytest
+mock==4.0.3               # via -r requirements/test.in
+packaging==20.8           # via -r requirements/test.in, pytest
 pluggy==0.13.1            # via pytest
-py==1.9.0                 # via pytest
+py==1.10.0                # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==4.1.0      # via -r requirements/test.in
-pytest==6.1.2             # via pytest-cov, pytest-django
+pytest==6.2.1             # via pytest-cov, pytest-django
 pytz==2020.4              # via -r requirements/base.txt, celery, django
 rules==2.2                # via -r requirements/test.in
-six==1.15.0               # via mock
 sqlparse==0.4.1           # via -r requirements/base.txt, django
-testfixtures==6.16.0      # via -r requirements/test.in
+testfixtures==6.17.0      # via -r requirements/test.in
 toml==0.10.2              # via pytest
-vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,9 +3,11 @@
 Tests for the ``django-user-tasks`` admin module.
 """
 
-from django.contrib.auth.models import User
+from django.contrib import auth
 from django.test import TestCase
 from django.urls import reverse
+
+User = auth.get_user_model()
 
 
 class AdminTestCase(TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,12 +8,14 @@ from uuid import uuid4
 
 import pytest
 
-from django.contrib.auth.models import User
+from django.contrib import auth
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from user_tasks.exceptions import TaskCanceledException
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
+
+User = auth.get_user_model()
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import mock
 import rules
 
-from django.contrib.auth.models import User
+from django.contrib import auth
 from django.urls import reverse
 from django.utils.timezone import now
 
@@ -19,6 +19,8 @@ from rest_framework.test import APITestCase
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from user_tasks.rules import add_rules
 from user_tasks.serializers import ArtifactSerializer, StatusSerializer
+
+User = auth.get_user_model()
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -7,7 +7,7 @@ import shutil
 from uuid import uuid4
 
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib import auth
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
@@ -17,6 +17,8 @@ from rest_framework.test import APIRequestFactory
 
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from user_tasks.serializers import ArtifactSerializer, StatusSerializer
+
+User = auth.get_user_model()
 
 
 def _format(datetime):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -12,7 +12,7 @@ from celery import chain, chord, group, shared_task
 from packaging import version
 from testfixtures import LogCapture
 
-from django.contrib.auth.models import User
+from django.contrib import auth
 from django.db import transaction
 from django.test import TestCase, TransactionTestCase, override_settings
 
@@ -20,6 +20,9 @@ from user_tasks import user_task_stopped
 from user_tasks.models import UserTaskStatus
 from user_tasks.signals import start_user_task
 from user_tasks.tasks import UserTask
+
+User = auth.get_user_model()
+
 
 CELERY_VERSION = version.parse(celery_version)
 LOGGER = logging.getLogger(__name__)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -9,12 +9,14 @@ from uuid import uuid4
 
 from celery import Task, shared_task
 
-from django.contrib.auth.models import User
+from django.contrib import auth
 from django.test import TestCase, override_settings
 from django.utils.timezone import now
 
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from user_tasks.tasks import UserTask, UserTaskMixin, purge_old_user_tasks
+
+User = auth.get_user_model()
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38}-django{22,30,31}-celery{44,50}-drf{39,310,311,312},quality,docs
+envlist = py{38,39}-django{22,30,31}-celery{44,50}-drf{39,310,311,312},quality,docs
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39}-django{22,30,31}-celery{44}-drf{39,310,311,312},quality,docs
+envlist = py{38}-django{22,30,31}-celery{44,50}-drf{39,310,311,312},quality,docs
 
 [testenv]
 deps =
@@ -10,6 +10,7 @@ deps =
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
     celery44: -r{toxinidir}/requirements/celery44.txt
+    celery50: -r{toxinidir}/requirements/celery50.txt
     -r{toxinidir}/requirements/test.txt
 commands =
     python -Wd -m pytest {posargs}

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 

--- a/user_tasks/signals.py
+++ b/user_tasks/signals.py
@@ -75,9 +75,17 @@ def _create_chain_entry(user_id, task_id, task_class, args, kwargs, callbacks, p
             if parent_name and not parent.name:
                 parent.set_name(parent_name)
     for callback in callbacks:
-        links = callback.options.get('link', [])
-        callback_class = import_string(callback.task)
-        _create_chain_entry(user_id, callback.id, callback_class, callback.args, callback.kwargs, links, parent=parent)
+        callback_class = import_string(callback['task'])
+
+        _create_chain_entry(
+            user_id,
+            callback['options']['task_id'],
+            callback_class,
+            callback['args'],
+            callback['kwargs'],
+            callback['options']['link'],
+            parent=parent
+        )
 
 
 def _create_chord_entry(task_id, task_class, message_body, user_id):
@@ -176,8 +184,8 @@ def _get_user_id(arguments_dict):
     user_id = arguments_dict['user_id']
     try:
         get_user_model().objects.get(pk=user_id)
-    except (ValueError, get_user_model().DoesNotExist):
-        raise TypeError('Invalid user_id: {}'.format(user_id))
+    except (ValueError, get_user_model().DoesNotExist) as import_exception:
+        raise TypeError('Invalid user_id: {}'.format(user_id)) from import_exception
     return user_id
 
 


### PR DESCRIPTION
Part1: https://github.com/edx/django-user-tasks/pull/106


This is Part2
https://openedx.atlassian.net/browse/BOM-2165

- Adding celery50 testing.

- `from celery.task import Task` is removed in celery5.0. Updated the `import` since its working in `4.4.7` also. Made some changes in code  [Documentation](https://docs.celeryproject.org/en/v4.4.7/internals/deprecation.html#removals-for-version-5-0)

- make upgrade using py3.8