### PR TITLE
Module celery.task will be removed in 5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+[1.3.2] - 2020-12-17
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
++++++++
+
+* Updated the deprecated celery import class. New import is compatible with 4.4.7 also.
+
+
 [1.3.1] - 2020-11-23
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 

--- a/user_tasks/tasks.py
+++ b/user_tasks/tasks.py
@@ -5,8 +5,7 @@ Celery task abstract base classes.
 import inspect
 import logging
 
-from celery import shared_task
-from celery.task import Task
+from celery import Task, shared_task
 
 from django.utils.timezone import now
 


### PR DESCRIPTION
Module celery.task will be removed in 5.0 but since new import is compatible with 4.4.7 so updating the code.

https://docs.celeryproject.org/en/v4.4.7/internals/deprecation.html#removals-for-version-5-0

This is 2nd PR https://github.com/edx/django-user-tasks/pull/104 where add the tox for testing.