### PR TITLE
feat: Bump the version and releasing new changes.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+[2.0.1] - 2021-05-28
+~~~~~~~~~~~~~~~~~~~~
+
+Added
++++++++
+
+* Added celery5.0 testing with tox. Update the import task command compatible with both celery 4.4.7 and celery5.0.
+
+
 [2.0.0] - 2021-01-20
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 


### PR DESCRIPTION
Bump the version 2.0.1.

Releasing https://github.com/edx/django-user-tasks/pull/104
and https://github.com/edx/django-user-tasks/pull/106
and few others changes.

I have added constraint in edx-platform. After testing on sandbox remove that constraint.
```
greater version requires testing. Will remove this constraint after testing.
django-user-tasks==1.3.2
```