### PR TITLE
chore: disabling the fail_ci_if_error temporarily.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,5 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         flags: unittests
-        fail_ci_if_error: true
+        fail_ci_if_error: false
 


### PR DESCRIPTION
chore: disabling the fail_ci_if_error temporarily.

https://github.com/codecov/codecov-action/issues/330