### PR TITLE
Move django rest swagger to drf-yasg

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,11 +55,12 @@ code-annotations==1.2.0
     #   edx-lint
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage==6.0
+coverage[toml]==6.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   codecov
+    #   edx-i18n-tools
     #   pytest-cov
 distlib==0.3.3
     # via
@@ -76,7 +77,7 @@ django-model-utils==4.1.1
     # via -r requirements/test.txt
 djangorestframework==3.12.4
     # via -r requirements/test.txt
-edx-i18n-tools==0.7.0
+edx-i18n-tools==0.8.0
     # via -r requirements/dev.in
 edx-lint==5.2.0
     # via
@@ -99,7 +100,7 @@ isort==5.9.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-jinja2==3.0.1
+jinja2==3.0.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -193,7 +194,7 @@ pytest==6.2.5
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements/test.txt
 pytest-django==4.4.0
     # via -r requirements/test.txt
@@ -221,7 +222,6 @@ six==1.16.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   edx-i18n-tools
     #   edx-lint
     #   tox
     #   virtualenv
@@ -250,11 +250,12 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pylint
     #   pytest
-    #   pytest-cov
     #   tox
 tomli==1.2.1
     # via
     #   -r requirements/pip-tools.txt
+    #   -r requirements/test.txt
+    #   coverage
     #   pep517
 tox==3.24.4
     # via

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -3,7 +3,7 @@
 
 -r base.txt               # Core dependencies for this package
 
-django-rest-swagger       # Generates a Swagger/Open API schema for the REST API
+drf_yasg                  # Generates a Swagger/Open API schema for the REST API
 doc8                      # reStructuredText style checker
 edx-sphinx-theme          # edX theme for Sphinx output
 rules                     # Needed to import user_tasks/rules.py for autodoc

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -35,11 +35,11 @@ charset-normalizer==2.0.6
 colorama==0.4.4
     # via twine
 coreapi==2.3.3
-    # via
-    #   django-rest-swagger
-    #   openapi-codec
+    # via drf-yasg
 coreschema==0.0.4
-    # via coreapi
+    # via
+    #   coreapi
+    #   drf-yasg
 cryptography==35.0.0
     # via secretstorage
 django==2.2.24
@@ -48,14 +48,13 @@ django==2.2.24
     #   -r requirements/base.txt
     #   django-model-utils
     #   djangorestframework
+    #   drf-yasg
 django-model-utils==4.1.1
     # via -r requirements/base.txt
-django-rest-swagger==2.2.0
-    # via -r requirements/doc.in
 djangorestframework==3.12.4
     # via
     #   -r requirements/base.txt
-    #   django-rest-swagger
+    #   drf-yasg
 doc8==0.9.1
     # via -r requirements/doc.in
 docutils==0.17.1
@@ -64,6 +63,8 @@ docutils==0.17.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
+drf-yasg==1.20.0
+    # via -r requirements/doc.in
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
 idna==3.2
@@ -74,13 +75,15 @@ importlib-metadata==4.8.1
     # via
     #   keyring
     #   twine
+inflection==0.5.1
+    # via drf-yasg
 itypes==1.2.0
     # via coreapi
 jeepney==0.7.1
     # via
     #   keyring
     #   secretstorage
-jinja2==3.0.1
+jinja2==3.0.2
     # via
     #   coreschema
     #   sphinx
@@ -95,11 +98,10 @@ kombu==4.6.11
     #   celery
 markupsafe==2.0.1
     # via jinja2
-openapi-codec==1.3.2
-    # via django-rest-swagger
 packaging==21.0
     # via
     #   bleach
+    #   drf-yasg
     #   sphinx
 pbr==5.6.0
     # via stevedore
@@ -138,12 +140,14 @@ restructuredtext-lint==1.3.2
     # via doc8
 rfc3986==1.5.0
     # via twine
+ruamel.yaml==0.17.16
+    # via drf-yasg
+ruamel.yaml.clib==0.2.6
+    # via ruamel.yaml
 rules==3.0
     # via -r requirements/doc.in
 secretstorage==3.3.1
     # via keyring
-simplejson==3.17.5
-    # via django-rest-swagger
 six==1.16.0
     # via
     #   bleach
@@ -181,7 +185,9 @@ tqdm==4.62.3
 twine==3.4.2
     # via -r requirements/doc.in
 uritemplate==3.0.1
-    # via coreapi
+    # via
+    #   coreapi
+    #   drf-yasg
 urllib3==1.26.7
     # via requests
 vine==1.3.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -23,7 +23,7 @@ isort==5.9.3
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==3.0.1
+jinja2==3.0.2
     # via code-annotations
 lazy-object-proxy==1.6.0
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,7 +15,7 @@ attrs==21.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-coverage==6.0
+coverage[toml]==6.0
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -46,7 +46,7 @@ pytest==6.2.5
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements/test.in
 pytest-django==4.4.0
     # via -r requirements/test.in
@@ -64,9 +64,9 @@ sqlparse==0.4.2
 testfixtures==6.18.3
     # via -r requirements/test.in
 toml==0.10.2
-    # via
-    #   pytest
-    #   pytest-cov
+    # via pytest
+tomli==1.2.1
+    # via coverage
     # via
     #   -r requirements/base.txt
     #   amqp

--- a/schema/settings.py
+++ b/schema/settings.py
@@ -10,7 +10,7 @@ DEBUG = True
 
 INSTALLED_APPS += (
     'django.contrib.staticfiles',
-    'rest_framework_swagger',
+    'drf_yasg',
 )
 
 MIDDLEWARE = (

--- a/schema/urls.py
+++ b/schema/urls.py
@@ -5,12 +5,31 @@ URLs for REST API schema generation.
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from rest_framework import permissions
+
 from user_tasks.urls import urlpatterns as base_patterns
 
 from .views import swagger
 
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Snippets API",
+      default_version='v1',
+      description="Test description",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@snippets.local"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=[permissions.AllowAny],
+)
+
 # The Swagger/Open API JSON file can be found at http://localhost:8000/?format=openapi
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    url('^$', swagger),
+    url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ] + base_patterns


### PR DESCRIPTION
This PR was created in order to remove django-rest-swagger package and use drf-yasg. 