### PR TITLE
docs: bump package version to 3.4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[3.4.2] - 2025-06-24
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+* Support Celery protocol V2 in create_user_tasks 
+
 
 [3.4.1] - 2025-04-20
 ~~~~~~~~~~~~~~~~~~~~

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '3.4.1'
+__version__ = '3.4.2'
 
 
 # This signal is emitted when a user task reaches any final state:


### PR DESCRIPTION
## Description
- Bump package version to `3.4.2` to release Celery protocol V2 support.