### PR TITLE
fix: Dropped django42 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
         python-version:
         - '3.11'
         - '3.12'
-        toxenv: [django42-celery53-drflatest, django52-celery54-drflatest,
-          quality, docs]
+        toxenv: [django52, quality, docs]
 
     steps:
     - uses: actions/checkout@v6
@@ -37,7 +36,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.11' && matrix.toxenv == 'django52-celery54-drflatest'
+      if: matrix.python-version == '3.11' && matrix.toxenv == 'django52'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.5.0] - 2025-12-08
+~~~~~~~~~~~~~~~~~~~~
+
+Removed
++++++++
+* Removed `django 4.2` support
+
 [3.4.3] - 2025-08-06
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -25,7 +32,8 @@ Fixed
 ~~~~~~~~~~~~~~~~~~~~
 
 Changed
-* Support Celery protocol V2 in create_user_tasks 
++++++++
+* Support Celery protocol V2 in create_user_tasks
 
 
 [3.4.1] - 2025-04-20
@@ -150,14 +158,6 @@ Changed
 +++++++
 
 * Added celery 5.0 testing using tox. Fix pylint warnings. Update the code accordingly.
-
-
-[1.3.2] - 2020-12-17
-~~~~~~~~~~~~~~~~~~~~
-
-Changed
-+++++++
-
 * Updated the deprecated celery import class. New import is compatible with 4.4.7 also.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,6 @@ Fixed
 ~~~~~~~~~~~~~~~~~~~~
 
 Changed
-+++++++
 * Support Celery protocol V2 in create_user_tasks
 
 
@@ -158,6 +157,14 @@ Changed
 +++++++
 
 * Added celery 5.0 testing using tox. Fix pylint warnings. Update the code accordingly.
+
+
+[1.3.2] - 2020-12-17
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
++++++++
+
 * Updated the deprecated celery import class. New import is compatible with 4.4.7 also.
 
 

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/quality.txt requirements/quality.in
 	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
-	# Let tox control the Django, djangorestframework, and celery versions for tests
+	# Let tox control the Django versions for tests
 	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
-	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
 	rm requirements/test.txt.tmp
 
 pull_translations: ## pull translations from Transifex

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,15 +6,15 @@
 #
 amqp==5.3.1
     # via kombu
-asgiref==3.10.0
+asgiref==3.11.0
     # via django
-billiard==4.2.2
+billiard==4.2.4
     # via celery
-celery==5.5.3
+celery==5.6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-click==8.3.0
+click==8.3.1
     # via
     #   celery
     #   click-didyoumean
@@ -26,7 +26,7 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-django==4.2.25
+django==5.2.9
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -41,9 +41,11 @@ djangorestframework==3.16.1
     #   drf-yasg
 drf-yasg==1.21.11
     # via -r requirements/base.in
+exceptiongroup==1.3.1
+    # via celery
 inflection==0.5.1
     # via drf-yasg
-kombu==5.5.4
+kombu==5.6.1
     # via celery
 packaging==25.0
     # via
@@ -59,10 +61,14 @@ pyyaml==6.0.3
     # via drf-yasg
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.3
+sqlparse==0.5.4
     # via django
+typing-extensions==4.15.0
+    # via exceptiongroup
 tzdata==2025.2
     # via kombu
+tzlocal==5.3.1
+    # via celery
 uritemplate==4.2.0
     # via drf-yasg
 vine==5.1.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-cachetools==6.2.1
+cachetools==6.2.2
     # via tox
 chardet==5.2.0
     # via tox
 colorama==0.4.6
     # via tox
-coverage==7.11.0
+coverage==7.12.0
     # via -r requirements/ci.in
 distlib==0.4.0
     # via virtualenv
@@ -22,7 +22,7 @@ packaging==25.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.5.0
+platformdirs==4.5.1
     # via
     #   tox
     #   virtualenv
@@ -30,7 +30,7 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-tox==4.31.0
+tox==4.32.0
     # via -r requirements/ci.in
-virtualenv==20.35.3
+virtualenv==20.35.4
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
 celery<6.0
+
+# greater version breaking docs build
+sphinx<8.2.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ amqp==5.3.1
     # via
     #   -r requirements/test.txt
     #   kombu
-asgiref==3.10.0
+asgiref==3.11.0
     # via
     #   -r requirements/test.txt
     #   django
@@ -17,13 +17,13 @@ astroid==3.3.11
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-billiard==4.2.2
+billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
-boto3==1.40.55
+boto3==1.42.4
     # via -r requirements/test.txt
-botocore==1.40.55
+botocore==1.42.4
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -32,11 +32,11 @@ build==1.3.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==6.2.1
+cachetools==6.2.2
     # via
     #   -r requirements/ci.txt
     #   tox
-celery==5.5.3
+celery==5.6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -44,7 +44,7 @@ chardet==5.2.0
     # via
     #   -r requirements/ci.txt
     #   tox
-click==8.3.0
+click==8.3.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -81,7 +81,7 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.11.0
+coverage[toml]==7.12.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -94,7 +94,7 @@ distlib==0.4.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==4.2.25
+django==5.2.9
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -119,6 +119,10 @@ edx-lint==5.6.0
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.txt
+exceptiongroup==1.3.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
 filelock==3.20.0
     # via
     #   -r requirements/ci.txt
@@ -145,7 +149,7 @@ jmespath==1.0.1
     #   -r requirements/test.txt
     #   boto3
     #   botocore
-kombu==5.5.4
+kombu==5.6.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -178,9 +182,9 @@ packaging==25.0
     #   tox
 path==16.16.0
     # via edx-i18n-tools
-pip-tools==7.5.1
+pip-tools==7.5.2
     # via -r requirements/pip-tools.txt
-platformdirs==4.5.0
+platformdirs==4.5.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -237,7 +241,7 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.4.2
+pytest==9.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -268,7 +272,7 @@ pyyaml==6.0.3
     #   edx-i18n-tools
 rules==3.5
     # via -r requirements/test.txt
-s3transfer==0.14.0
+s3transfer==0.16.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -282,15 +286,15 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-sqlparse==0.5.3
+sqlparse==0.5.4
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.5.0
+stevedore==5.6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-testfixtures==9.2.0
+testfixtures==10.0.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -300,17 +304,25 @@ tomlkit==0.13.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.31.0
+tox==4.32.0
     # via -r requirements/ci.txt
+typing-extensions==4.15.0
+    # via
+    #   -r requirements/test.txt
+    #   exceptiongroup
 tzdata==2025.2
     # via
     #   -r requirements/test.txt
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
 uritemplate==4.2.0
     # via
     #   -r requirements/test.txt
     #   drf-yasg
-urllib3==2.5.0
+urllib3==2.6.0
     # via
     #   -r requirements/test.txt
     #   botocore
@@ -320,7 +332,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.35.3
+virtualenv==20.35.4
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ amqp==5.3.1
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.10.0
+asgiref==3.11.0
     # via
     #   -r requirements/base.txt
     #   django
@@ -26,23 +26,21 @@ babel==2.17.0
     #   sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
-beautifulsoup4==4.14.2
+beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-billiard==4.2.2
+billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.5.3
+celery==5.6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-certifi==2025.10.5
+certifi==2025.11.12
     # via requests
-cffi==2.0.0
-    # via cryptography
 charset-normalizer==3.4.4
     # via requests
-click==8.3.0
+click==8.3.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -67,11 +65,9 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==46.0.3
-    # via secretstorage
 deepmerge==2.0
     # via sphinxcontrib-openapi
-django==4.2.25
+django==5.2.9
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -99,6 +95,10 @@ docutils==0.21.2
     #   sphinx-mdinclude
 drf-yasg==1.21.11
     # via -r requirements/base.txt
+exceptiongroup==1.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
 id==1.5.0
     # via twine
 idna==3.11
@@ -119,10 +119,6 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.3.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   coreschema
@@ -131,9 +127,9 @@ jsonschema==4.25.1
     # via sphinxcontrib-openapi
 jsonschema-specifications==2025.9.1
     # via jsonschema
-keyring==25.6.0
+keyring==25.7.0
     # via twine
-kombu==5.5.4
+kombu==5.6.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -149,7 +145,7 @@ more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.1
+nh3==0.3.2
     # via readme-renderer
 openapi-codec==1.3.2
     # via django-rest-swagger
@@ -167,8 +163,6 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/base.txt
     #   click-repl
-pycparser==2.23
-    # via cffi
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pygments==2.19.2
@@ -208,7 +202,7 @@ requests==2.32.5
     #   twine
 requests-toolbelt==1.0.0
     # via twine
-restructuredtext-lint==1.4.0
+restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via twine
@@ -216,14 +210,12 @@ rich==14.2.0
     # via twine
 roman-numerals-py==3.1.0
     # via sphinx
-rpds-py==0.27.1
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
 rules==3.5
     # via -r requirements/doc.in
-secretstorage==3.4.0
-    # via keyring
 simplejson==3.20.2
     # via django-rest-swagger
 six==1.17.0
@@ -237,6 +229,7 @@ soupsieve==2.8
     # via beautifulsoup4
 sphinx==8.2.3
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
@@ -263,29 +256,35 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.3
+sqlparse==0.5.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.5.0
+stevedore==5.6.0
     # via doc8
 twine==6.2.0
     # via -r requirements/doc.in
 typing-extensions==4.15.0
     # via
+    #   -r requirements/base.txt
     #   beautifulsoup4
+    #   exceptiongroup
     #   pydata-sphinx-theme
     #   referencing
 tzdata==2025.2
     # via
     #   -r requirements/base.txt
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
 uritemplate==4.2.0
     # via
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.5.0
+urllib3==2.6.0
     # via
     #   requests
     #   twine

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,11 +6,11 @@
 #
 build==1.3.0
     # via pip-tools
-click==8.3.0
+click==8.3.1
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.5.1
+pip-tools==7.5.2
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.45.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.2
+pip==25.3
     # via -r requirements/pip.in
 setuptools==80.9.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
-click==8.3.0
+click==8.3.1
     # via
     #   click-log
     #   code-annotations
@@ -31,7 +31,7 @@ markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
-platformdirs==4.5.0
+platformdirs==4.5.1
     # via pylint
 pycodestyle==2.14.0
     # via -r requirements/quality.in
@@ -59,7 +59,7 @@ six==1.17.0
     # via edx-lint
 snowballstemmer==3.0.1
     # via pydocstyle
-stevedore==5.5.0
+stevedore==5.6.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,25 +8,25 @@ amqp==5.3.1
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.10.0
+asgiref==3.11.0
     # via
     #   -r requirements/base.txt
     #   django
-billiard==4.2.2
+billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.40.55
+boto3==1.42.4
     # via -r requirements/test.in
-botocore==1.40.55
+botocore==1.42.4
     # via
     #   boto3
     #   s3transfer
-celery==5.5.3
+celery==5.6.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-click==8.3.0
+click==8.3.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -45,7 +45,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-coverage[toml]==7.11.0
+coverage[toml]==7.12.0
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -58,11 +58,16 @@ django-model-utils==5.0.0
     # via -r requirements/base.txt
 django-storages==1.14.6
     # via -r requirements/test.in
+djangorestframework==3.16.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
 drf-yasg==1.21.11
     # via -r requirements/base.txt
+exceptiongroup==1.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
@@ -73,7 +78,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-kombu==5.5.4
+kombu==5.6.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -96,7 +101,7 @@ prompt-toolkit==3.0.52
     #   click-repl
 pygments==2.19.2
     # via pytest
-pytest==8.4.2
+pytest==9.0.2
     # via
     #   pytest-cov
     #   pytest-django
@@ -119,27 +124,35 @@ pyyaml==6.0.3
     #   drf-yasg
 rules==3.5
     # via -r requirements/test.in
-s3transfer==0.14.0
+s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via
     #   -r requirements/base.txt
     #   python-dateutil
-sqlparse==0.5.3
+sqlparse==0.5.4
     # via
     #   -r requirements/base.txt
     #   django
-testfixtures==9.2.0
+testfixtures==10.0.0
     # via -r requirements/test.in
+typing-extensions==4.15.0
+    # via
+    #   -r requirements/base.txt
+    #   exceptiongroup
 tzdata==2025.2
     # via
     #   -r requirements/base.txt
     #   kombu
+tzlocal==5.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
 uritemplate==4.2.0
     # via
     #   -r requirements/base.txt
     #   drf-yasg
-urllib3==2.5.0
+urllib3==2.6.0
     # via botocore
 vine==5.1.0
     # via

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
-        'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
 envlist =
-    py{311,312}-django{42, 52}-celery{53, 54}-drf{313,latest}
+    py{311,312}-django{52}
     quality
     docs
 [testenv]
 deps =
-    django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
-    drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt
 commands =
     python -Wd -m pytest --cov user_tasks {posargs}

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '3.4.4'
+__version__ = '3.5.0'
 
 
 # This signal is emitted when a user task reaches any final state:


### PR DESCRIPTION
https://github.com/openedx/public-engineering/issues/458

- Removed `Django 4.2 `and run make upgrade with `django5.2`
- Updated all Python dependencies to their latest compatible versions
- Cleaned up test environments and CI configuration to remove Django 4.2 references
