### PR TITLE
chore: drop Django 4.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
         os: [ubuntu-latest]
         python-version:
         - '3.12'
-        toxenv: [django42-celery53-drflatest, django52-celery54-drflatest,
-          quality, docs]
+        toxenv: [django52-celery54-drflatest, quality, docs]
 
     steps:
     - uses: actions/checkout@v6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,13 +29,14 @@ click-repl==0.3.0
 django==5.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-model-utils
     #   djangorestframework
     #   drf-yasg
 django-model-utils==5.0.0
     # via -r requirements/base.in
-djangorestframework==3.16.1
+djangorestframework==3.17.0
     # via
     #   -r requirements/base.in
     #   drf-yasg

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-cachetools==7.0.3
+cachetools==7.0.5
     # via tox
 colorama==0.4.6
     # via tox
-coverage==7.13.4
+coverage==7.13.5
     # via -r requirements/ci.in
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   python-discovery
     #   tox
@@ -30,11 +30,11 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.1.0
+python-discovery==1.2.0
     # via virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.49.0
+tox==4.50.3
     # via -r requirements/ci.in
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
 celery<6.0
+
+# Django 4.2 support was dropped; only Django 5.2+ is supported.
+Django>=5.2,<6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,9 +21,9 @@ billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
-boto3==1.42.62
+boto3==1.42.74
     # via -r requirements/test.txt
-botocore==1.42.62
+botocore==1.42.74
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -32,7 +32,7 @@ build==1.4.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==7.0.3
+cachetools==7.0.5
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -69,7 +69,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/test.txt
     #   celery
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -77,7 +77,7 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -93,6 +93,7 @@ distlib==0.4.0
 django==5.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-model-utils
     #   django-storages
@@ -103,19 +104,19 @@ django-model-utils==5.0.0
     # via -r requirements/test.txt
 django-storages==1.14.6
     # via -r requirements/test.txt
-djangorestframework==3.16.1
+djangorestframework==3.17.0
     # via
     #   -r requirements/test.txt
     #   drf-yasg
 drf-yasg==1.21.15
     # via -r requirements/test.txt
-edx-i18n-tools==1.9.0
+edx-i18n-tools==2.0.0
     # via -r requirements/dev.in
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.txt
-filelock==3.25.0
+filelock==3.25.2
     # via
     #   -r requirements/ci.txt
     #   python-discovery
@@ -241,7 +242,7 @@ pytest==9.0.2
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt
@@ -250,7 +251,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/test.txt
     #   botocore
     #   celery
-python-discovery==1.1.0
+python-discovery==1.2.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -293,7 +294,7 @@ stevedore==5.7.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-testfixtures==10.0.0
+testfixtures==11.0.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -307,7 +308,7 @@ tomlkit==0.14.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.49.0
+tox==4.50.3
     # via -r requirements/ci.txt
 tzdata==2025.3
     # via
@@ -331,7 +332,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.1.0
+virtualenv==21.2.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,7 +16,7 @@ asgiref==3.11.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
@@ -36,9 +36,7 @@ celery==5.6.2
     #   -r requirements/base.txt
 certifi==2026.2.25
     # via requests
-cffi==2.0.0
-    # via cryptography
-charset-normalizer==3.4.5
+charset-normalizer==3.4.6
     # via requests
 click==8.3.1
     # via
@@ -65,13 +63,12 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==46.0.5
-    # via secretstorage
 deepmerge==2.0
     # via sphinxcontrib-openapi
 django==5.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-model-utils
     #   djangorestframework
@@ -80,7 +77,7 @@ django-model-utils==5.0.0
     # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/doc.in
-djangorestframework==3.16.1
+djangorestframework==3.17.0
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -111,14 +108,10 @@ itypes==1.2.0
     # via coreapi
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   coreschema
@@ -154,7 +147,6 @@ packaging==26.0
     #   -r requirements/base.txt
     #   drf-yasg
     #   kombu
-    #   pydata-sphinx-theme
     #   sphinx
     #   twine
 picobox==4.0.0
@@ -163,9 +155,7 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/base.txt
     #   click-repl
-pycparser==3.0
-    # via cffi
-pydata-sphinx-theme==0.15.4
+pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
 pygments==2.19.2
     # via
@@ -217,8 +207,6 @@ rpds-py==0.30.0
     #   referencing
 rules==3.5
     # via -r requirements/doc.in
-secretstorage==3.5.0
-    # via keyring
 simplejson==3.20.2
     # via django-rest-swagger
 six==1.17.0
@@ -237,7 +225,7 @@ sphinx==9.1.0
     #   sphinx-mdinclude
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-openapi
-sphinx-book-theme==1.1.4
+sphinx-book-theme==1.2.0
     # via -r requirements/doc.in
 sphinx-mdinclude==0.6.2
     # via sphinxcontrib-openapi

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ wheel==0.46.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==26.0.1
     # via -r requirements/pip.in
-setuptools==82.0.0
+setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,11 +15,11 @@ click==8.3.1
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.3.2
+code-annotations==3.0.0
     # via edx-lint
 dill==0.4.1
     # via pylint
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via -r requirements/quality.in
 isort==8.0.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,9 +16,9 @@ billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.42.62
+boto3==1.42.74
     # via -r requirements/test.in
-botocore==1.42.62
+botocore==1.42.74
     # via
     #   boto3
     #   s3transfer
@@ -45,10 +45,11 @@ click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-model-utils
     #   django-storages
@@ -100,7 +101,7 @@ pytest==9.0.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 pytest-django==4.12.0
     # via -r requirements/test.in
@@ -129,7 +130,7 @@ sqlparse==0.5.5
     # via
     #   -r requirements/base.txt
     #   django
-testfixtures==10.0.0
+testfixtures==11.0.0
     # via -r requirements/test.in
 tzdata==2025.3
     # via

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
-        'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
-    py{312}-django{42, 52}-celery{53, 54}-drf{313,latest}
+    py{312}-django{52}-celery{54}-drf{313,latest}
     quality
     docs
 [testenv]
 deps =
-    django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
     drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
Remove Django 4.2 from CI matrix, tox envlist, setup.py classifiers, and all requirements files. Only Django 5.2 is now supported.

Issue: https://github.com/openedx/public-engineering/issues/458